### PR TITLE
Do not process CSS modules on declared resources

### DIFF
--- a/packages/roc-plugin-style-css/src/css/index.js
+++ b/packages/roc-plugin-style-css/src/css/index.js
@@ -36,8 +36,8 @@ export default ({ settings, previousValue: rocBuilder }) => (target) => () => {
         currentExtensions = currentExtensions.concat(extensions);
         currentLoaders = currentLoaders.concat(loaders);
     });
-    const toMatch = new RegExp(currentExtensions.map((extension) => `\\.${extension}$`).join('|'));
 
+    const toMatch = new RegExp(currentExtensions.map((extension) => `\\.${extension}$`).join('|'));
     const globalStylePaths = getGlobalStylePaths(toMatch);
 
     // Create general style loader
@@ -66,7 +66,7 @@ export default ({ settings, previousValue: rocBuilder }) => (target) => () => {
                 }
             },
             loader: ExtractTextPlugin.extract(require.resolve('style-loader'),
-                cssPipeline('css-loader', currentLoaders, settings, DIST))
+                cssPipeline('css-loader', currentLoaders, settings, DIST, false))
         });
     }
 

--- a/packages/roc-plugin-style-css/src/css/pipeline.js
+++ b/packages/roc-plugin-style-css/src/css/pipeline.js
@@ -1,6 +1,6 @@
-export default function cssPipeline(base, loaders, settings, isDist) {
+export default function cssPipeline(base, loaders, settings, isDist, cssModulesEnabled = true) {
     let moduleSettings = '';
-    if (settings.build.style.modules) {
+    if (settings.build.style.modules && cssModulesEnabled) {
         moduleSettings = '&module&localIdentName=';
 
         // Define how the class names should be defined


### PR DESCRIPTION
Fixes a regression bug created when moving this functionality into a plugin
