### PR TITLE
Disabled removal of deprecated vendor prefixes from css-loader

### DIFF
--- a/packages/roc-plugin-style-css/src/css/pipeline.js
+++ b/packages/roc-plugin-style-css/src/css/pipeline.js
@@ -16,6 +16,6 @@ export default function cssPipeline(base, loaders, settings, isDist, cssModulesE
         '';
 
     // We set importLoaders to nr. loaders + 1 to get css-loader to process everything through the pipeline
-    return `${require.resolve(base)}?sourceMap?importLoaders=${loaders.length + 1}${moduleSettings}` +
+    return `${require.resolve(base)}?-autoprefixer&sourceMap?importLoaders=${loaders.length + 1}${moduleSettings}` +
         `!${require.resolve('postcss-loader')}${extraLoaders}`;
 }


### PR DESCRIPTION
We need this since it will otherwise remove prefixes added by autoprefixer through postcss-loader.
