### PR TITLE
sourceMap option to enable/disable css source maps

### DIFF
--- a/extensions/roc-plugin-style-css/docs/Hooks.md
+++ b/extensions/roc-plugin-style-css/docs/Hooks.md
@@ -15,7 +15,7 @@ Expected to return new settings that should be merged with the existing ones.
 Makes it possible to modify the settings object before a command is started and after potential arguments from the command line and configuration file have been parsed. This is a good point to default to some value if no was given or modify something in the settings.
 
 __Initial value:__ _Nothing_  
-__Expected return value:__ `{}`
+__Expected return value:__ `Object()`
 
 #### Arguments
 
@@ -34,4 +34,4 @@ Important that the _actions_ return an object matching the following:
 `{ extensions: String/[String], loaders: String/[String] }`
 
 __Initial value:__ _Nothing_  
-__Expected return value:__ `{String / [String]}`
+__Expected return value:__ `Object(String / Array(String))`

--- a/extensions/roc-plugin-style-css/docs/Settings.md
+++ b/extensions/roc-plugin-style-css/docs/Settings.md
@@ -5,10 +5,11 @@
 
 ### Style
 
-| Name     | Description                                          | Path                              | CLI option                          | Default               | Type                | Required | Can be empty | Extensions           |
-| -------- | ---------------------------------------------------- | --------------------------------- | ----------------------------------- | --------------------- | ------------------- | -------- | ------------ | -------------------- |
-| modules  | If CSS Modules should be enabled.                    | build.style.modules               | --build-style-modules               | `true`                | `Boolean`           | Yes      |              | roc-plugin-style-css |
-| name     | The naming pattern to use for the built style files. | build.style.name                  | --build-style-name                  | `"[name].[hash].css"` | `String`            | Yes      | No           | roc-plugin-style-css |
+| Name      | Description                                          | Path                              | CLI option                          | Default               | Type                | Required | Can be empty | Extensions           |
+| --------- | ---------------------------------------------------- | --------------------------------- | ----------------------------------- | --------------------- | ------------------- | -------- | ------------ | -------------------- |
+| modules   | If CSS Modules should be enabled.                    | build.style.modules               | --build-style-modules               | `true`                | `Boolean`           | Yes      |              | roc-plugin-style-css |
+| sourceMap | If CSS source maps should be enabled.                | build.style.sourceMap             | --build-style-sourceMap             | `false`               | `Boolean`           | No       | Yes          | roc-plugin-style-css |
+| name      | The naming pattern to use for the built style files. | build.style.name                  | --build-style-name                  | `"[name].[hash].css"` | `String`            | Yes      | No           | roc-plugin-style-css |
 
 #### Autoprefixer
 

--- a/extensions/roc-plugin-style-css/docs/Settings.md
+++ b/extensions/roc-plugin-style-css/docs/Settings.md
@@ -5,16 +5,16 @@
 
 ### Style
 
-| Name      | Description                                          | Path                              | CLI option                          | Default               | Type                | Required | Can be empty | Extensions           |
-| --------- | ---------------------------------------------------- | --------------------------------- | ----------------------------------- | --------------------- | ------------------- | -------- | ------------ | -------------------- |
-| modules   | If CSS Modules should be enabled.                    | build.style.modules               | --build-style-modules               | `true`                | `Boolean`           | Yes      |              | roc-plugin-style-css |
-| sourceMap | If CSS source maps should be enabled.                | build.style.sourceMap             | --build-style-sourceMap             | `false`               | `Boolean`           | No       | Yes          | roc-plugin-style-css |
-| name      | The naming pattern to use for the built style files. | build.style.name                  | --build-style-name                  | `"[name].[hash].css"` | `String`            | Yes      | No           | roc-plugin-style-css |
+| Name      | Description                                          | Path                              | CLI option                          | Default               | Type                     | Required | Can be empty | Extensions           |
+| --------- | ---------------------------------------------------- | --------------------------------- | ----------------------------------- | --------------------- | ------------------------ | -------- | ------------ | -------------------- |
+| modules   | If CSS Modules should be enabled.                    | build.style.modules               | --build-style-modules               | `true`                | `Boolean`                | Yes      |              | roc-plugin-style-css |
+| name      | The naming pattern to use for the built style files. | build.style.name                  | --build-style-name                  | `"[name].[hash].css"` | `String`                 | Yes      | No           | roc-plugin-style-css |
+| sourceMap | If CSS source maps should be enabled.                | build.style.sourceMap             | --build-style-sourceMap             | `false`               | `Boolean`                | No       |              | roc-plugin-style-css |
 
 #### Autoprefixer
 
 ✓ ― Supports __raw
 
-| Name     | Description                                          | Path                              | CLI option                          | Default               | Type                | Required | Can be empty | Extensions           |
-| -------- | ---------------------------------------------------- | --------------------------------- | ----------------------------------- | --------------------- | ------------------- | -------- | ------------ | -------------------- |
-| browsers | What browsers that should be supported.              | build.style.autoprefixer.browsers | --build-style-autoprefixer-browsers | `"last 2 version"`    | `String / [String]` | No       |              | roc-plugin-style-css |
+| Name      | Description                                          | Path                              | CLI option                          | Default               | Type                     | Required | Can be empty | Extensions           |
+| --------- | ---------------------------------------------------- | --------------------------------- | ----------------------------------- | --------------------- | ------------------------ | -------- | ------------ | -------------------- |
+| browsers  | What browsers that should be supported.              | build.style.autoprefixer.browsers | --build-style-autoprefixer-browsers | `"last 2 version"`    | `String / Array(String)` | No       |              | roc-plugin-style-css |

--- a/extensions/roc-plugin-style-css/src/config/roc.config.js
+++ b/extensions/roc-plugin-style-css/src/config/roc.config.js
@@ -4,6 +4,7 @@ export default {
             style: {
                 name: '[name].[hash].css',
                 modules: true,
+                sourceMap: false,
                 autoprefixer: {
                     __raw: {},
                     browsers: 'last 2 version',

--- a/extensions/roc-plugin-style-css/src/config/roc.config.meta.js
+++ b/extensions/roc-plugin-style-css/src/config/roc.config.meta.js
@@ -20,6 +20,10 @@ export default {
                     description: 'If CSS Modules should be enabled.',
                     validator: required(isBoolean),
                 },
+                sourceMap: {
+                    description: 'If CSS source maps should be enabled.',
+                    validator: isBoolean,
+                },
             },
         },
     },

--- a/extensions/roc-plugin-style-css/src/css/index.js
+++ b/extensions/roc-plugin-style-css/src/css/index.js
@@ -16,6 +16,7 @@ export default ({ context: { config: { settings } }, previousValue: webpackConfi
     const DIST = settings.build.mode === 'dist';
     const WEB = target === 'web';
     const NODE = target === 'node';
+    const sourceMap = settings.build.style.sourceMap;
 
     const getGlobalStylePaths = (toMatch) => {
         if (WEB && settings.build.resources) {
@@ -47,7 +48,7 @@ export default ({ context: { config: { settings } }, previousValue: webpackConfi
     const loader = NODE ?
         'css-loader/locals' :
         'css-loader';
-    const styleLoader = (cssModules) => cssPipeline(loader, currentLoaders, DIST, cssModules);
+    const styleLoader = (cssModules) => cssPipeline(loader, currentLoaders, DIST, sourceMap, cssModules);
 
     // Add CSS Modules loader
     newWebpackConfig.module.loaders.push({

--- a/extensions/roc-plugin-style-css/src/css/pipeline.js
+++ b/extensions/roc-plugin-style-css/src/css/pipeline.js
@@ -1,6 +1,8 @@
 export default function cssPipeline(base, loaders, isDist, sourceMap = false, cssModulesEnabled = true) {
     let moduleSettings = '';
-    let sourceMapSettings = '';
+    const sourceMapSettings = sourceMap ?
+        'sourceMap&' :
+        '';
 
     if (cssModulesEnabled) {
         moduleSettings = '&modules&localIdentName=';
@@ -12,9 +14,6 @@ export default function cssPipeline(base, loaders, isDist, sourceMap = false, cs
             moduleSettings += '[path]_[name]__[local]___[hash:base64:5]';
         }
     }
-    if (sourceMap) {
-        sourceMapSettings = 'sourceMap';
-    }
 
     const extraLoaders = loaders.length > 0 ?
         `!${loaders.join('!')}` :
@@ -22,7 +21,7 @@ export default function cssPipeline(base, loaders, isDist, sourceMap = false, cs
 
     // We set importLoaders to nr. loaders + 1 to get css-loader to process everything through the pipeline
     return `${require.resolve(base)}?` +
-        `${sourceMapSettings}&` +
+        `${sourceMapSettings}` +
         '-autoprefixer&' +
         `importLoaders=${loaders.length + 1}` +
         `${moduleSettings}` +

--- a/extensions/roc-plugin-style-css/src/css/pipeline.js
+++ b/extensions/roc-plugin-style-css/src/css/pipeline.js
@@ -1,5 +1,7 @@
-export default function cssPipeline(base, loaders, isDist, cssModulesEnabled = true) {
+export default function cssPipeline(base, loaders, isDist, sourceMap = false, cssModulesEnabled = true) {
     let moduleSettings = '';
+    let sourceMapSettings = '';
+
     if (cssModulesEnabled) {
         moduleSettings = '&modules&localIdentName=';
 
@@ -10,12 +12,20 @@ export default function cssPipeline(base, loaders, isDist, cssModulesEnabled = t
             moduleSettings += '[path]_[name]__[local]___[hash:base64:5]';
         }
     }
+    if (sourceMap) {
+        sourceMapSettings = 'sourceMap';
+    }
 
     const extraLoaders = loaders.length > 0 ?
         `!${loaders.join('!')}` :
         '';
 
     // We set importLoaders to nr. loaders + 1 to get css-loader to process everything through the pipeline
-    return `${require.resolve(base)}?-autoprefixer&importLoaders=${loaders.length + 1}${moduleSettings}` +
-        `!${require.resolve('postcss-loader')}${extraLoaders}`;
+    return `${require.resolve(base)}?` +
+        `${sourceMapSettings}&` +
+        '-autoprefixer&' +
+        `importLoaders=${loaders.length + 1}` +
+        `${moduleSettings}` +
+        `!${require.resolve('postcss-loader')}` +
+        `${extraLoaders}`;
 }


### PR DESCRIPTION
By default sourceMap is set to false to be consistent with the previous
behaviour.

Being able to control this option via the config or command line allows
us to have more flexibility. It was previously a hard coded value.