### PR TITLE
Update autoprefixer to the latest version

### DIFF
--- a/extensions/roc-plugin-style-css/package.json
+++ b/extensions/roc-plugin-style-css/package.json
@@ -26,7 +26,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "autoprefixer": "~6.1.2",
+    "autoprefixer": "~6.6.1",
     "css-loader": "~0.23.0",
     "extract-text-webpack-plugin": "~0.8.2",
     "node-noop": "1.0.0",


### PR DESCRIPTION
This should fix an error some have been seeing from Browserlist.

```
BrowserslistError: Unknown browser query `op_mini all`
```