### PR TITLE
Use webpack target for detecting 'node' target platform

### DIFF
--- a/extensions/roc-plugin-style-css/src/css/index.js
+++ b/extensions/roc-plugin-style-css/src/css/index.js
@@ -15,7 +15,7 @@ export default ({ context: { config: { settings } }, previousValue: webpackConfi
     const DEV = settings.build.mode === 'dev';
     const DIST = settings.build.mode === 'dist';
     const WEB = target === 'web';
-    const NODE = target === 'node';
+    const NODE = webpackConfig.target === 'node';
     const sourceMap = settings.build.style.sourceMap;
 
     const getGlobalStylePaths = (toMatch) => {


### PR DESCRIPTION
Since there can be multiple Roc targets targeting Webpack target 'node'
and we are only interested in target platform and not specific
Roc target, `NODE` build option shouldn't rely on Roc target name.

This change adds support for 'static' build target to roc-package-web-app
by fixing failing build step, caused by 'static' target not being
treated as node-like target platform.