### PR TITLE
Hook for injecting style loaders into the pipeline

### DIFF
--- a/extensions/roc-plugin-style-css/src/css/index.js
+++ b/extensions/roc-plugin-style-css/src/css/index.js
@@ -35,11 +35,13 @@ export default ({ context: { config: { settings } }, previousValue: webpackConfi
     // Get extensions and loaders
     const styles = [{ extensions: ['css'], loaders: [], preLoaders: [] }];
     invokeHook('add-style')(({ extensions, loaders }) => {
-        styles.push({ extensions: [].concat(extensions), loaders: [].concat(loaders) });
+        styles.push({ extensions: [].concat(extensions), loaders: [].concat(loaders), preLoaders: [] });
     });
 
-    invokeHook('css-preloaders')((loaders) => {
-      styles[0].preLoaders = [...loaders];
+    invokeHook('add-style-preloaders')((loaders) => {
+        styles.forEach(({ preLoaders }, i) => {
+            styles[i].preLoaders = preLoaders.concat(loaders);
+        });
     });
 
     // Create a seperate pipeline for each `add-style` invocation

--- a/extensions/roc-plugin-style-css/src/css/index.js
+++ b/extensions/roc-plugin-style-css/src/css/index.js
@@ -35,7 +35,7 @@ export default ({ context: { config: { settings } }, previousValue: webpackConfi
     // Get extensions and loaders
     const styles = [{ extensions: ['css'], loaders: [] }];
     invokeHook('add-style')(({ extensions, loaders }) => {
-        styles.push({ extensions: [].concat(extensions), loaders: [].concat(loaders), preLoaders: [] });
+        styles.push({ extensions: [].concat(extensions), loaders: [].concat(loaders) });
     });
 
     let preLoaders = [];

--- a/extensions/roc-plugin-style-css/src/css/index.js
+++ b/extensions/roc-plugin-style-css/src/css/index.js
@@ -33,13 +33,17 @@ export default ({ context: { config: { settings } }, previousValue: webpackConfi
     };
 
     // Get extensions and loaders
-    const styles = [{ extensions: ['css'], loaders: [] }];
+    const styles = [{ extensions: ['css'], loaders: [], preLoaders: [] }];
     invokeHook('add-style')(({ extensions, loaders }) => {
         styles.push({ extensions: [].concat(extensions), loaders: [].concat(loaders) });
     });
 
+    invokeHook('css-preloaders')((loaders) => {
+      styles[0].preLoaders = [...loaders];
+    });
+
     // Create a seperate pipeline for each `add-style` invocation
-    styles.forEach(({ extensions, loaders }) => {
+    styles.forEach(({ extensions, loaders, preLoaders }) => {
         // We allow stylesheet files to end with a query string
         const toMatch = new RegExp(extensions.map((extension) => `\\.${extension}(\\?.*)?$`).join('|'));
         const globalStylePaths = getGlobalStylePaths(toMatch);
@@ -48,7 +52,7 @@ export default ({ context: { config: { settings } }, previousValue: webpackConfi
         const loader = NODE ?
             'css-loader/locals' :
             'css-loader';
-        const styleLoader = (cssModules) => cssPipeline(loader, loaders, DIST, sourceMap, cssModules);
+        const styleLoader = (cssModules) => cssPipeline(loader, loaders, DIST, sourceMap, cssModules, preLoaders);
 
         // Add CSS Modules loader
         newWebpackConfig.module.loaders.push({

--- a/extensions/roc-plugin-style-css/src/css/index.js
+++ b/extensions/roc-plugin-style-css/src/css/index.js
@@ -33,19 +33,18 @@ export default ({ context: { config: { settings } }, previousValue: webpackConfi
     };
 
     // Get extensions and loaders
-    const styles = [{ extensions: ['css'], loaders: [], preLoaders: [] }];
+    const styles = [{ extensions: ['css'], loaders: [] }];
     invokeHook('add-style')(({ extensions, loaders }) => {
         styles.push({ extensions: [].concat(extensions), loaders: [].concat(loaders), preLoaders: [] });
     });
 
+    let preLoaders = [];
     invokeHook('add-style-preloaders')((loaders) => {
-        styles.forEach(({ preLoaders }, i) => {
-            styles[i].preLoaders = preLoaders.concat(loaders);
-        });
+        preLoaders = preLoaders.concat(loaders);
     });
 
     // Create a seperate pipeline for each `add-style` invocation
-    styles.forEach(({ extensions, loaders, preLoaders }) => {
+    styles.forEach(({ extensions, loaders }) => {
         // We allow stylesheet files to end with a query string
         const toMatch = new RegExp(extensions.map((extension) => `\\.${extension}(\\?.*)?$`).join('|'));
         const globalStylePaths = getGlobalStylePaths(toMatch);

--- a/extensions/roc-plugin-style-css/src/css/pipeline.js
+++ b/extensions/roc-plugin-style-css/src/css/pipeline.js
@@ -3,7 +3,7 @@ export default function cssPipeline(base,
                                     isDist,
                                     sourceMap = false,
                                     cssModulesEnabled = true,
-                                    ploaders) {
+                                    preLoaders) {
     let moduleSettings = '';
     const sourceMapSettings = sourceMap ?
         'sourceMap&' :
@@ -24,17 +24,19 @@ export default function cssPipeline(base,
         `!${loaders.join('!')}` :
         '';
 
-    const preLoaders = (ploaders && ploaders.length > 0) ?
-        `!${ploaders.join('!')}` :
+    const ploaders = (preLoaders && preLoaders.length > 0) ?
+        `!${preLoaders.join('!')}` :
         '';
+
+    const nLoaders = loaders.length + preLoaders.length + 1
 
     // We set importLoaders to nr. loaders + 1 to get css-loader to process everything through the pipeline
     return `${require.resolve(base)}?` +
         `${sourceMapSettings}` +
         '-autoprefixer&' +
-        `importLoaders=${loaders.length + 1}` +
+        `importLoaders=${nLoaders}` +
         `${moduleSettings}` +
-        `${preLoaders}` +
+        `${ploaders}` +
         `!${require.resolve('postcss-loader')}` +
         `${extraLoaders}`;
 }

--- a/extensions/roc-plugin-style-css/src/css/pipeline.js
+++ b/extensions/roc-plugin-style-css/src/css/pipeline.js
@@ -1,9 +1,4 @@
-export default function cssPipeline(base,
-                                    loaders,
-                                    isDist,
-                                    sourceMap = false,
-                                    cssModulesEnabled = true,
-                                    preLoaders) {
+export default function cssPipeline(base, loaders, isDist, sourceMap = false, cssModulesEnabled = true, preLoaders) {
     let moduleSettings = '';
     const sourceMapSettings = sourceMap ?
         'sourceMap&' :

--- a/extensions/roc-plugin-style-css/src/css/pipeline.js
+++ b/extensions/roc-plugin-style-css/src/css/pipeline.js
@@ -1,4 +1,9 @@
-export default function cssPipeline(base, loaders, isDist, sourceMap = false, cssModulesEnabled = true, ploaders = null) {
+export default function cssPipeline(base,
+                                    loaders,
+                                    isDist,
+                                    sourceMap = false,
+                                    cssModulesEnabled = true,
+                                    ploaders) {
     let moduleSettings = '';
     const sourceMapSettings = sourceMap ?
         'sourceMap&' :

--- a/extensions/roc-plugin-style-css/src/css/pipeline.js
+++ b/extensions/roc-plugin-style-css/src/css/pipeline.js
@@ -28,7 +28,7 @@ export default function cssPipeline(base,
         `!${preLoaders.join('!')}` :
         '';
 
-    const nLoaders = loaders.length + preLoaders.length + 1
+    const nLoaders = loaders.length + preLoaders.length + 1;
 
     // We set importLoaders to nr. loaders + 1 to get css-loader to process everything through the pipeline
     return `${require.resolve(base)}?` +

--- a/extensions/roc-plugin-style-css/src/css/pipeline.js
+++ b/extensions/roc-plugin-style-css/src/css/pipeline.js
@@ -1,4 +1,4 @@
-export default function cssPipeline(base, loaders, isDist, sourceMap = false, cssModulesEnabled = true) {
+export default function cssPipeline(base, loaders, isDist, sourceMap = false, cssModulesEnabled = true, ploaders = null) {
     let moduleSettings = '';
     const sourceMapSettings = sourceMap ?
         'sourceMap&' :
@@ -19,12 +19,17 @@ export default function cssPipeline(base, loaders, isDist, sourceMap = false, cs
         `!${loaders.join('!')}` :
         '';
 
+    const preLoaders = (ploaders && ploaders.length > 0) ?
+        `!${ploaders.join('!')}` :
+        '';
+
     // We set importLoaders to nr. loaders + 1 to get css-loader to process everything through the pipeline
     return `${require.resolve(base)}?` +
         `${sourceMapSettings}` +
         '-autoprefixer&' +
         `importLoaders=${loaders.length + 1}` +
         `${moduleSettings}` +
+        `${preLoaders}` +
         `!${require.resolve('postcss-loader')}` +
         `${extraLoaders}`;
 }

--- a/extensions/roc-plugin-style-css/src/roc/index.js
+++ b/extensions/roc-plugin-style-css/src/roc/index.js
@@ -1,4 +1,4 @@
-import { isArray, isObject, isString, oneOf, isRegex } from 'roc/validators';
+import { isArray, isObject, isString, oneOf } from 'roc/validators';
 import { lazyFunctionRequire } from 'roc';
 
 import config from '../config/roc.config.js';

--- a/extensions/roc-plugin-style-css/src/roc/index.js
+++ b/extensions/roc-plugin-style-css/src/roc/index.js
@@ -27,11 +27,9 @@ export default {
         },
         'add-style-preloaders': {
             description: `
-            Used to preloaders to style.
+            Used to add general loaders early in the chain, before the PostCSS loader.
 
-            Important that the _actions_ return a list of loaders:
-
-            \`[loarder1, loader1, ...]\``,
+            These loaders will be applied to all styles added from the \`add-style\` hook.`,
             hasCallback: true,
             returns: isArray(isString),
         },

--- a/extensions/roc-plugin-style-css/src/roc/index.js
+++ b/extensions/roc-plugin-style-css/src/roc/index.js
@@ -1,4 +1,4 @@
-import { isArray, isObject, isString, oneOf } from 'roc/validators';
+import { isArray, isObject, isString, oneOf, isRegex } from 'roc/validators';
 import { lazyFunctionRequire } from 'roc';
 
 import config from '../config/roc.config.js';
@@ -24,6 +24,16 @@ export default {
             \`{ extensions: String/[String], loaders: String/[String] }\``,
             hasCallback: true,
             returns: isObject(oneOf(isString, isArray(isString))),
+        },
+        'css-preloaders': {
+            description: `
+            Used to preloaders to style.
+
+            Important that the _actions_ return a list of loaders:
+
+            \`[loarder1, loader1, ...]\``,
+            hasCallback: true,
+            //returns: isObject(oneOf(isObject, isArray, is)),
         },
     },
 };

--- a/extensions/roc-plugin-style-css/src/roc/index.js
+++ b/extensions/roc-plugin-style-css/src/roc/index.js
@@ -25,7 +25,7 @@ export default {
             hasCallback: true,
             returns: isObject(oneOf(isString, isArray(isString))),
         },
-        'css-preloaders': {
+        'add-style-preloaders': {
             description: `
             Used to preloaders to style.
 
@@ -33,7 +33,7 @@ export default {
 
             \`[loarder1, loader1, ...]\``,
             hasCallback: true,
-            //returns: isObject(oneOf(isObject, isArray, is)),
+            returns: isArray(isString),
         },
     },
 };


### PR DESCRIPTION
Add a new hook `add-style-preloaders`, to add the ability of injecting style loaders, before the loading of the CSS to the DOM or before creating css files, the loaders will be executed just after the postcss-loader. The hook action should return an array of loaders.